### PR TITLE
Implement and use topology labels

### DIFF
--- a/api/core/v1alpha1/loadbalancer_types.go
+++ b/api/core/v1alpha1/loadbalancer_types.go
@@ -45,7 +45,7 @@ type LoadBalancerSpec struct {
 	Ports []LoadBalancerPort `json:"ports,omitempty"`
 
 	// Selector selects all Instance that are managed by this daemon set.
-	Selector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Template is the instance template.
 	Template InstanceTemplate `json:"template"`

--- a/api/core/v1alpha1/well_known_labels.go
+++ b/api/core/v1alpha1/well_known_labels.go
@@ -19,4 +19,8 @@ const (
 
 	IPFamilyLabel = "apinet.api.onmetal.de/ip-family"
 	IPIPLabel     = "apinet.api.onmetal.de/ip"
+
+	TopologyLabelPrefix    = "topology.core.apinet.api.onmetal.de/"
+	TopologyPartitionLabel = TopologyLabelPrefix + "partition"
+	TopologyZoneLabel      = TopologyLabelPrefix + "zone"
 )

--- a/apinetlet/controllers/loadbalancer_controller_test.go
+++ b/apinetlet/controllers/loadbalancer_controller_test.go
@@ -65,6 +65,25 @@ var _ = Describe("LoadBalancerController", func() {
 					"IPFamily": Equal(corev1.IPv4Protocol),
 					"Name":     Equal("ipv4"),
 				})),
+				"Selector": Equal(&metav1.LabelSelector{
+					MatchLabels: apinetletclient.SourceLabels(k8sClient.Scheme(), k8sClient.RESTMapper(), loadBalancer),
+				}),
+				"Template": Equal(v1alpha1.InstanceTemplate{
+					Spec: v1alpha1.InstanceSpec{
+						Affinity: &v1alpha1.Affinity{
+							InstanceAntiAffinity: &v1alpha1.InstanceAntiAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.InstanceAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: apinetletclient.SourceLabels(k8sClient.Scheme(), k8sClient.RESTMapper(), loadBalancer),
+										},
+										TopologyKey: v1alpha1.TopologyZoneLabel,
+									},
+								},
+							},
+						},
+					},
+				}),
 			}))),
 		)
 	})

--- a/client-go/applyconfigurations/core/v1alpha1/loadbalancerspec.go
+++ b/client-go/applyconfigurations/core/v1alpha1/loadbalancerspec.go
@@ -30,7 +30,7 @@ type LoadBalancerSpecApplyConfiguration struct {
 	NetworkRef *v1.LocalObjectReference                `json:"networkRef,omitempty"`
 	IPs        []LoadBalancerIPApplyConfiguration      `json:"ips,omitempty"`
 	Ports      []LoadBalancerPortApplyConfiguration    `json:"ports,omitempty"`
-	Selector   *metav1.LabelSelectorApplyConfiguration `json:"nodeSelector,omitempty"`
+	Selector   *metav1.LabelSelectorApplyConfiguration `json:"selector,omitempty"`
 	Template   *InstanceTemplateApplyConfiguration     `json:"template,omitempty"`
 }
 

--- a/client-go/applyconfigurations/internal/internal.go
+++ b/client-go/applyconfigurations/internal/internal.go
@@ -395,15 +395,15 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
       default: {}
-    - name: nodeSelector
-      type:
-        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
     - name: ports
       type:
         list:
           elementType:
             namedType: com.github.onmetal.onmetal-api-net.api.core.v1alpha1.LoadBalancerPort
           elementRelationship: atomic
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
     - name: template
       type:
         namedType: com.github.onmetal.onmetal-api-net.api.core.v1alpha1.InstanceTemplate

--- a/client-go/openapi/api_violations.report
+++ b/client-go/openapi/api_violations.report
@@ -150,7 +150,6 @@ API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1al
 API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1alpha1,InstanceStatus,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1alpha1,LoadBalancerRouting,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1alpha1,LoadBalancerSpec,IPs
-API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1alpha1,LoadBalancerSpec,Selector
 API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1alpha1,LoadBalancerStatus,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1alpha1,NATGatewaySpec,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api-net/api/core/v1alpha1,NATTable,IPs

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1553,7 +1553,7 @@ func schema_onmetal_api_net_api_core_v1alpha1_LoadBalancerSpec(ref common.Refere
 							},
 						},
 					},
-					"nodeSelector": {
+					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selector selects all Instance that are managed by this daemon set.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),

--- a/cmd/metalnetlet/main.go
+++ b/cmd/metalnetlet/main.go
@@ -60,6 +60,7 @@ func init() {
 
 func main() {
 	var name string
+	var nodeLabels map[string]string
 
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -70,6 +71,7 @@ func main() {
 	var metalnetNamespace string
 
 	flag.StringVar(&name, "name", "", "The name of the partition the metalnetlet represents (required).")
+	flag.StringToStringVar(&nodeLabels, "node-label", nodeLabels, "Additional labels to add to the nodes.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -154,6 +156,7 @@ func main() {
 		Client:         mgr.GetClient(),
 		MetalnetClient: metalnetCluster.GetClient(),
 		PartitionName:  name,
+		NodeLabels:     nodeLabels,
 	}).SetupWithManager(mgr, metalnetCluster.GetCache()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MetalnetNode")
 		os.Exit(1)

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
-github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onmetal/controller-utils v0.8.1 h1:2B7s/2SBfEtrp0u+1VDyxmecYTBmOIX9u+ZmQhEZqIo=
 github.com/onmetal/controller-utils v0.8.1/go.mod h1:qbStb7obY06G70iOg7wuKYRH+MiJ6emZvzuUEAj5VUQ=
 github.com/onmetal/metalnet v0.1.0 h1:KnwFz7/3IA/WzPDZOcpVPzV1Y09y1LZWxsz8tWeAfbc=

--- a/internal/apis/core/well_known_labels.go
+++ b/internal/apis/core/well_known_labels.go
@@ -19,4 +19,8 @@ const (
 
 	IPFamilyLabel = "apinet.api.onmetal.de/ip-family"
 	IPIPLabel     = "apinet.api.onmetal.de/ip"
+
+	TopologyLabelPrefix    = "topology.core.apinet.api.onmetal.de/"
+	TopologyPartitionLabel = TopologyLabelPrefix + "partition"
+	TopologyZoneLabel      = TopologyLabelPrefix + "zone"
 )

--- a/metalnetlet/controllers/controllers_suite_test.go
+++ b/metalnetlet/controllers/controllers_suite_test.go
@@ -65,6 +65,12 @@ const (
 	partitionName = "test-metalnetlet"
 )
 
+var (
+	nodeLabels = map[string]string{
+		"the": "node",
+	}
+)
+
 func TestControllers(t *testing.T) {
 	SetDefaultConsistentlyPollingInterval(pollingInterval)
 	SetDefaultEventuallyPollingInterval(pollingInterval)
@@ -153,6 +159,7 @@ func SetupTest(metalnetNs *corev1.Namespace) {
 			Client:         k8sManager.GetClient(),
 			MetalnetClient: k8sManager.GetClient(),
 			PartitionName:  partitionName,
+			NodeLabels:     nodeLabels,
 		}).SetupWithManager(k8sManager, k8sManager.GetCache())).To(Succeed())
 
 		Expect((&NetworkInterfaceReconciler{

--- a/metalnetlet/controllers/metalnetnode_controller.go
+++ b/metalnetlet/controllers/metalnetnode_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onmetal/controller-utils/clientutils"
 	metalnetv1alpha1 "github.com/onmetal/metalnet/api/v1alpha1"
 	"github.com/onmetal/onmetal-api-net/api/core/v1alpha1"
+	"github.com/onmetal/onmetal-api/utils/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,7 @@ type MetalnetNodeReconciler struct {
 	client.Client
 	MetalnetClient client.Client
 	PartitionName  string
+	NodeLabels     map[string]string
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
@@ -135,6 +137,9 @@ func (r *MetalnetNodeReconciler) reconcile(ctx context.Context, log logr.Logger,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: PartitionNodeName(r.PartitionName, metalnetNode.Name),
+			Labels: maps.AppendMap(map[string]string{
+				v1alpha1.TopologyPartitionLabel: r.PartitionName,
+			}, r.NodeLabels),
 		},
 	}
 	if err := r.Patch(ctx, node, client.Apply, PartitionFieldOwner(r.PartitionName), client.ForceOwnership); err != nil {

--- a/metalnetlet/controllers/metalnetnode_controller_test.go
+++ b/metalnetlet/controllers/metalnetnode_controller_test.go
@@ -40,7 +40,10 @@ var _ = Describe("MetalnetNodeController", func() {
 				Name: PartitionNodeName(partitionName, metalnetNode.Name),
 			},
 		}
-		Eventually(Get(node)).Should(Succeed())
+		Eventually(Object(node)).Should(HaveField("Labels", map[string]string{
+			"the":                           "node",
+			v1alpha1.TopologyPartitionLabel: partitionName,
+		}))
 
 		By("deleting the metalnet node")
 		Expect(k8sClient.Delete(ctx, metalnetNode)).To(Succeed())


### PR DESCRIPTION
Automatically add zone and partition topology labels to metalnet-managed nodes
Use the topology zone label in `apinetlet`'s load balancer controller to get anti-affine load balancer instance scheduling.